### PR TITLE
Make total row Start/End values optional via settings and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,15 @@ Each table contains one or more work rows. A row can include:
 
 The plugin calculates:
 * the duration of each completed row
-* the earliest start time
+* the earliest visible start time
 * the summed total duration
-* a total end time derived from total start plus total duration
+
+By default, the **Total** row shows:
+* **Start** = earliest visible start time
+* **End** = derived end time calculated as earliest visible start plus total summed duration
+
+If you do not want these values, enable **Hide Start/End in Total row** in the plugin settings so the Total row only shows duration totals.
+
 Only rows with both **Start** and **End** values are included in the calculations.
 
 ### Time input
@@ -82,6 +88,16 @@ When enabled:
 The plugin still accepts:
 * 24-hour input such as `14:30`
 * 12-hour input such as `2:30 PM`
+
+### `disableTotalRowTimeRange`
+When enabled:
+* the **Total** row leaves Start and End empty
+* only the duration totals are shown
+
+When disabled:
+* the **Total** row shows a Start and End value
+* **Start** is the earliest visible start time in the table
+* **End** is a derived value: earliest start plus total summed duration
 
 ### `dialogPrefillJson`
 Use this setting to prefill the dialog with your own default rows and offsets.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ const WORKTIME_TABLE_EDIT_MODEL_FN = "wtEditWorktimeTable";
 
 const SETTINGS_DIALOG_PREFILL_JSON = "dialogPrefillJson";
 const SETTINGS_USE_12_HOUR_CLOCK = "use12HourClock";
+const SETTINGS_DISABLE_TOTAL_ROW_TIME_RANGE = "disableTotalRowTimeRange";
 
 let rendererRegistered = false;
 
@@ -225,6 +226,11 @@ function readUse12HourClockFromSettings(): boolean {
   return Boolean(s?.[SETTINGS_USE_12_HOUR_CLOCK]);
 }
 
+function readDisableTotalRowTimeRangeFromSettings(): boolean {
+  const s = (logseq as any).settings as Record<string, unknown> | undefined;
+  return Boolean(s?.[SETTINGS_DISABLE_TOTAL_ROW_TIME_RANGE]);
+}
+
 function withInlineEditButton(tableMarkdown: string): string {
   return `${WORKTIME_TABLE_RENDERER_MACRO}\n${tableMarkdown}`;
 }
@@ -373,6 +379,7 @@ async function commandWorktime(): Promise<void> {
     const md = withInlineEditButton(
       buildMarkdownTable(calculated, {
         use12HourClock: readUse12HourClockFromSettings(),
+        showTotalRowTimeRange: !readDisableTotalRowTimeRangeFromSettings(),
       }),
     );
     await insertAtCursor(md);
@@ -456,6 +463,7 @@ async function commandEditTable(contextUuid?: string): Promise<void> {
     const md = withInlineEditButton(
       buildMarkdownTable(calculated, {
         use12HourClock: readUse12HourClockFromSettings(),
+        showTotalRowTimeRange: !readDisableTotalRowTimeRangeFromSettings(),
       }),
     );
 
@@ -519,6 +527,7 @@ async function commandExportCsv(contextUuid?: string): Promise<void> {
 
   const csv = buildCsvTable(calculated, {
     use12HourClock: readUse12HourClockFromSettings(),
+    showTotalRowTimeRange: !readDisableTotalRowTimeRangeFromSettings(),
   });
   const filename = await suggestCsvFilenameFromBlock(uuid);
   downloadTextFile(filename, csv);
@@ -530,26 +539,32 @@ function registerCommands(): void {
   const alreadyInit = Boolean(g[INIT_GUARD_KEY]);
   if (!alreadyInit) g[INIT_GUARD_KEY] = true;
 
-  if (!alreadyInit) {
-    logseq.useSettingsSchema([
-      {
-        key: SETTINGS_DIALOG_PREFILL_JSON,
-        type: "string",
-        default: "",
-        title: "Dialog prefill (JSON)",
-        description:
-          'Advanced: JSON object to prefill the dialog, e.g. {"rows":[{"start":"08:00","end":"","task":""}],"offsets":[{"hours":1,"task":"Break"}]}',
-      },
-      {
-        key: SETTINGS_USE_12_HOUR_CLOCK,
-        type: "boolean",
-        default: false,
-        title: "Use 12-hour clock (AM/PM)",
-        description:
-          "If enabled, Start/End times are displayed as h:mm AM/PM. Input accepts both 24h and 12h formats.",
-      },
-    ]);
-  }
+  logseq.useSettingsSchema([
+    {
+      key: SETTINGS_DIALOG_PREFILL_JSON,
+      type: "string",
+      default: "",
+      title: "Dialog prefill (JSON)",
+      description:
+        'Advanced: JSON object to prefill the dialog, e.g. {"rows":[{"start":"08:00","end":"","task":""}],"offsets":[{"hours":1,"task":"Break"}]}',
+    },
+    {
+      key: SETTINGS_USE_12_HOUR_CLOCK,
+      type: "boolean",
+      default: false,
+      title: "Use 12-hour clock (AM/PM)",
+      description:
+        "If enabled, Start/End times are displayed as h:mm AM/PM. Input accepts both 24h and 12h formats.",
+    },
+    {
+      key: SETTINGS_DISABLE_TOTAL_ROW_TIME_RANGE,
+      type: "boolean",
+      default: false,
+      title: "Disable Start/End in Total row",
+      description:
+        "If enabled, the Total row hides Start and End and only shows duration totals. If disabled, the Total row shows the earliest visible Start and a derived End computed as earliest Start plus total duration.",
+    },
+  ]);
 
   activateThisInstance();
 

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -68,6 +68,10 @@ function formatClockCell(value: string, use12HourClock: boolean): string {
     : formatMinutesToClock24(minutes);
 }
 
+function formatBoldCell(value: string): string {
+  return value.length > 0 ? `**${value}**` : "";
+}
+
 export interface OffsetRow {
   task: string;
   minutes: number;
@@ -118,7 +122,10 @@ export function calculateRows(rows: InputRow[]): CalculatedRow[] {
 
 export function buildMarkdownTable(
   calculatedRows: CalculatedRow[],
-  options?: { use12HourClock?: boolean },
+  options?: {
+    use12HourClock?: boolean;
+    showTotalRowTimeRange?: boolean;
+  },
 ): string {
   const header = `${WORKTIME_TABLE_HEADER}\n${WORKTIME_TABLE_SEPARATOR}\n`;
 
@@ -150,31 +157,32 @@ export function buildMarkdownTable(
 
   const totalHHMM = formatMinutesToHHMM(totalMinutes);
   const totalIndustrialStr = totalIndustrial.toFixed(2);
+  const showTotalRowTimeRange = Boolean(options?.showTotalRowTimeRange);
 
   const totalStart =
-    earliestStartMinutes === null
+    !showTotalRowTimeRange || earliestStartMinutes === null
       ? ""
       : Boolean(options?.use12HourClock)
         ? formatMinutesToClock12(earliestStartMinutes)
         : formatMinutesToClock24(earliestStartMinutes);
 
   const totalEnd =
-    earliestStartMinutes === null
+    !showTotalRowTimeRange || earliestStartMinutes === null
       ? ""
       : Boolean(options?.use12HourClock)
         ? formatMinutesToClock12(earliestStartMinutes + totalMinutes)
         : formatMinutesToClock24(earliestStartMinutes + totalMinutes);
 
   const footer =
-    "| **Total** | **" +
-    totalStart +
-    "** | **" +
-    totalEnd +
-    "** | **" +
-    totalHHMM +
-    "** | **" +
-    totalIndustrialStr +
-    "** |\n";
+    "| **Total** | " +
+    formatBoldCell(totalStart) +
+    " | " +
+    formatBoldCell(totalEnd) +
+    " | " +
+    formatBoldCell(totalHHMM) +
+    " | " +
+    formatBoldCell(totalIndustrialStr) +
+    " |\n";
 
   return header + (body ? body + "\n" : "") + footer;
 }
@@ -189,9 +197,13 @@ function escapeCsvCell(value: string): string {
 
 export function buildCsvTable(
   calculatedRows: CalculatedRow[],
-  options?: { use12HourClock?: boolean },
+  options?: {
+    use12HourClock?: boolean;
+    showTotalRowTimeRange?: boolean;
+  },
 ): string {
   const use12HourClock = Boolean(options?.use12HourClock);
+  const showTotalRowTimeRange = Boolean(options?.showTotalRowTimeRange);
 
   let totalMinutes = 0;
   let totalIndustrial = 0;
@@ -232,14 +244,14 @@ export function buildCsvTable(
   const totalIndustrialStr = totalIndustrial.toFixed(2);
 
   const totalStart =
-    earliestStartMinutes === null
+    !showTotalRowTimeRange || earliestStartMinutes === null
       ? ""
       : use12HourClock
         ? formatMinutesToClock12(earliestStartMinutes)
         : formatMinutesToClock24(earliestStartMinutes);
 
   const totalEnd =
-    earliestStartMinutes === null
+    !showTotalRowTimeRange || earliestStartMinutes === null
       ? ""
       : use12HourClock
         ? formatMinutesToClock12(earliestStartMinutes + totalMinutes)


### PR DESCRIPTION
Closes #2 

Makes the `Start` and `End` values in the `Total` row optional via settings.
It also updates the README to better explain the current total row behavior and when those values are useful.